### PR TITLE
fix broken phpunit execution by using version 5.6.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "twilio/sdk": "^5.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.0"
+        "phpunit/phpunit": "5.6.1"
     },
     "autoload": {
         "classmap": [


### PR DESCRIPTION
Hi guys.

Great fun to work with twillo sms!

The sampleclient unittests are broken with a fatal exception. The cause is an outdated phpunit version.
phpunit 4.x MUST be updated to a higher version, In that case phpunit 5.6.1 solved the problem.

This patch uses phpunit 5.6.1 to solve the problem.

"All" tests are running now
