### PR TITLE
Devedsb update env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 APP_ENV=local
-APP_DEBUG=true
+APP_DEBUG=false
 APP_KEY=SomeRandomString
 
 TWILIO_AUTH_TOKEN=

--- a/readme.md
+++ b/readme.md
@@ -15,40 +15,39 @@ Use Twilio to create SMS alerts so that you never miss a critical issue.
 1. Grab latest source
 
    ```bash
-   $ git clone git@github.com:TwilioDevEd/server-notifications-laravel.git
+   git clone git@github.com:TwilioDevEd/server-notifications-laravel.git
    ```
 
 1. Copy the sample configuration file and edit it to match your configuration.
 
    ```bash
-   $ cp .env.example .env
+   cp .env.example .env
    ```
-
-  You can find your `TWILIO_ACCOUNT_SID` and `TWILIO_AUTH_TOKEN` under
-  your [Twilio Account Settings](https://www.twilio.com/user/account/settings).
-  You can buy Twilio phone numbers at
-  [Twilio numbers](https://www.twilio.com/user/account/phone-numbers/search)
-  `TWILIO_NUMBER` should be set to the phone number you purchased above.
-  `TWILIO_RR_NUMBER` should be set to a Twilio number too.
+   You can find your `TWILIO_ACCOUNT_SID` and `TWILIO_AUTH_TOKEN` under
+   your [Twilio Account Settings](https://www.twilio.com/user/account/settings).
+   You can buy Twilio phone numbers at
+   [Twilio numbers](https://www.twilio.com/user/account/phone-numbers/search)
+   `TWILIO_NUMBER` should be set to the phone number you purchased above.
+   `TWILIO_RR_NUMBER` should be set to a Twilio number too.
 
 1. Customize `config/administrators.json` with your name and phone number.
 
 1. Install the dependencies with [Composer](https://getcomposer.org/).
 
    ```bash
-   $ composer install
+   composer install
    ```
 
 1. Generate an `APP_KEY`.
 
    ```bash
-   $ php artisan key:generate
+   php artisan key:generate
    ```
 
 1. Start the server.
 
    ```bash
-   $ php artisan serve
+   php artisan serve
    ```
 
 ### How To Demo?


### PR DESCRIPTION
Avoids exposing sensible variables on production.

Changes in the PR:

- APP_DEBUG to false
- Improve Readme


Not possible due to the Laravel version:

- debug_blacklist to avoid exposing sensible variables even when debug is true. It was added in Laravel 5.5.13, and project version is Laravel 5.1